### PR TITLE
Updates to r6 to explain support for multiple n-ary relation types

### DIFF
--- a/spec/1_related_tables.adoc
+++ b/spec/1_related_tables.adoc
@@ -119,7 +119,7 @@ For each row in `gpkgext_relations` there SHALL be a table or view of the name r
 [caption=""]
 .Requirement 6
 ====
-For user-defined media tables as referenced in `gpkgext_relations`, if the value of its foreign column (as specified in <<gpkgext_relations_table>>) is not null, the corresponding user-defined primary table (specified by `gpkgext_relations`) SHALL contain a row with an `id` corresponding to the value in that foreign column.
+For any user-defined media table, as referenced in `gpkgext_relations`, if the value of its `foreign_column` (as specified in <<gpkgext_relations_table>>) is not null, the corresponding user-defined primary table (specified by `gpkgext_relations`) SHALL contain at least one a row with a value in its `primary_column` (specified by `gpkgext_relations`) equal to the value in the user-defined media table `foreign_column`.
 ====
 For example:
 
@@ -134,15 +134,21 @@ For example:
 |=======================================================================
 |feature_id|primary_column|
 |1|7|
+|2|7|
+|3|8|
 |=======================================================================
 
 .media
 |=======================================================================
 |id|data|content_type|foreign_column
 |17|<BLOB>|image/png|7
+|18|<BLOB>|image/png|8
+|19|<BLOB>|image/png|8
 |=======================================================================
 
-For each row of media with a non-null foreign_column, there must be a row in features with a matching id in the  primary_column.
+For each row of media with a non-null foreign_column, there must be at least one row in features with a matching id in the  primary_column.
+
+It is important to note that this allows for many-to-many, one-to-many and many-to-one relationships between features and related media.
 
 === Table Definition SQL
 


### PR DESCRIPTION
RTE-IE action item  - explains how the current relationship definition in the related tables supports mappings such as many-to-many and one-to-many both ways without requiring mapping tables.