### PR TITLE
Accommodate related tables data outside of defined requirements classes

### DIFF
--- a/standard/clause_7_normative_text.adoc
+++ b/standard/clause_7_normative_text.adoc
@@ -68,6 +68,7 @@ include::requirements/REQ007.adoc[]
 [NOTE]
 ====
 See <<gpkgext_user_defined_mapping_table_sql>> for example SQL for defining a user-defined mapping table.
+A user-defined mapping table MAY also contain other columns not listed here.
 ====
 
 ===== Table Values

--- a/standard/clause_7_normative_text.adoc
+++ b/standard/clause_7_normative_text.adoc
@@ -4,7 +4,7 @@
 include::requirements/requirements_class_Table_Definitions.adoc[]
 
 ==== `gpkg_extensions`
-===== Table Values 
+===== Table Values
 include::requirements/REQ001.adoc[]
 
 include::requirements/REQ002.adoc[]
@@ -48,6 +48,8 @@ include::requirements/REQ005.adoc[]
 
 include::requirements/REQ006.adoc[]
 
+include::requirements/REQ006-5.adoc[]
+
 [[user_defined_mapping_table]]
 ==== User-Defined Mapping Tables
 ===== Table Definition
@@ -75,7 +77,7 @@ include::requirements/REQ009.adoc[]
 
 [NOTE]
 ====
-This specification makes no statement on the cardinality of a user-defined mapping table. It MAY contain no rows or have a one-to-many, many-to-one, or many-to-many relationship. While it is possible to enforce a one-to-many or many-to-one relationship by applying a UNIQUE constraint to the `attributes_id` or `base_id` respectively, this is NOT RECOMMENDED because the presence of these constraints is not exposed by SQLite in an easy-to-query manner. 
+This specification makes no statement on the cardinality of a user-defined mapping table. It MAY contain no rows or have a one-to-many, many-to-one, or many-to-many relationship. While it is possible to enforce a one-to-many or many-to-one relationship by applying a UNIQUE constraint to the `attributes_id` or `base_id` respectively, this is NOT RECOMMENDED because the presence of these constraints is not exposed by SQLite in an easy-to-query manner.
 ====
 
 [[user_defined_related_data_table]]
@@ -93,7 +95,7 @@ include::requirements/REQ011.adoc[]
 include::requirements/REQ012.adoc[]
 
 [[gpkg_user_defined_media_table]]
-.User-Defined Media Table Definition 
+.User-Defined Media Table Definition
 [cols=",,,,",options="header",]
 |=======================================================================
 |Column Name    |Column Type |Column Description        |Null |Key
@@ -118,7 +120,7 @@ include::requirements/REQ013.adoc[]
 include::requirements/REQ014.adoc[]
 
 [[gpkg_user_defined_simpleattr_table]]
-.User-Defined Simple Attributes Table Definition 
+.User-Defined Simple Attributes Table Definition
 [cols=",,,,",options="header",]
 |================================================================================
 |Column Name    |Column Type |Column Description                      |Null |Key

--- a/standard/requirements/REQ006-5.adoc
+++ b/standard/requirements/REQ006-5.adoc
@@ -1,0 +1,8 @@
+[[r6]]
+[width="90%",cols="2,6"]
+|===
+|*Requirement 6.5* {set:cellbgcolor:#CACCCE}|/req/table-defs/ger_relname +
+ +
+Each `relation_name` column in a `gpkgext_relations` row SHALL either match a `relation_name` from the Requirements Classes for User-Defined Related Data Tables in this specification (e.g. <<Requirement Class 2 – Media>>), or be of the form `x-`<author>_<relation_name> where <author> indicates the person or organization that developed and maintains this set of User-Defined Related Tables.
+ {set:cellbgcolor:#FFFFFF}
+|===

--- a/standard/requirements/REQ006-5.adoc
+++ b/standard/requirements/REQ006-5.adoc
@@ -3,6 +3,6 @@
 |===
 |*Requirement 6.5* {set:cellbgcolor:#CACCCE}|/req/table-defs/ger_relname +
  +
-Each `relation_name` column in a `gpkgext_relations` row SHALL either match a `relation_name` from the Requirements Classes for User-Defined Related Data Tables in this specification (e.g. <<Requirement Class 2 – Media>>), or be of the form `x-`<author>_<relation_name> where <author> indicates the person or organization that developed and maintains this set of User-Defined Related Tables.
+Each `relation_name` column in a `gpkgext_relations` row SHALL either match a `relation_name` from the Requirements Classes for User-Defined Related Data Tables in this specification (e.g. `media` for <<Media Requirement Class>>), or be of the form `x-`<author>_<relation_name> where <author> indicates the person or organization that developed and maintains this set of User-Defined Related Tables.
  {set:cellbgcolor:#FFFFFF}
 |===

--- a/standard/requirements/REQ007.adoc
+++ b/standard/requirements/REQ007.adoc
@@ -4,6 +4,7 @@
 |*Requirement 7* {set:cellbgcolor:#CACCCE}|/req/table-defs/udmt +
  +
 
-A user-defined mapping table or view SHALL conform to <<gpkgext_user_defined_mapping_table>>.
+A user-defined mapping table or view SHALL contain all of the columns described in <<gpkgext_user_defined_mapping_table>>.
+
 {set:cellbgcolor:#FFFFFF}
 |===


### PR DESCRIPTION
closes #34 

x-<author>_<relation_name> format for new relation types

Additional fields in mapping table will facilitate graph database capability

Gives developers a standards-compliant way to produce experimental related table data beyond the types we've defined.

I did not re-number requirements but happy to do that work once we decide this new one is in the right spot.