### PR TITLE
Update REQ006.adoc

### DIFF
--- a/standard/requirements/REQ006.adoc
+++ b/standard/requirements/REQ006.adoc
@@ -4,7 +4,15 @@
 |*Requirement 6* {set:cellbgcolor:#CACCCE}|/req/table-defs/ger_related +
  +
 
-For each row in `gpkgext_relations`, the `related_table_name` column SHALL contain the name of a user-defined attributes table as described by <<user_defined_related_data_table>>.
+For each row in `gpkgext_relations`, there SHALL be a table of the name referenced in `related_table_name` and that table SHALL have an entry in `gpkg_contents`.
 {set:cellbgcolor:#FFFFFF}
 |===
 
+[width="90%",cols="2,6"]
+|===
+|*Requirement 6A* {set:cellbgcolor:#CACCCE}|/req/table-defs/ger_related_udrdt +
+ +
+
+For each row in `gpkgext_relations`, the `related_table_name` column SHALL contain the name of a user-defined related data table as described by <<user_defined_related_data_table>>.
+{set:cellbgcolor:#FFFFFF}
+|===


### PR DESCRIPTION
This makes req 5 and 6 symmetric, and changes the wording for new req 6A to reflect the heading at 6.1.4 (related data, not attributes).

Yes, we need to renumber, again.