### PR TITLE
Remove not-null constraint on simpleattr

### DIFF
--- a/standard/clause_7_normative_text.adoc
+++ b/standard/clause_7_normative_text.adoc
@@ -134,11 +134,11 @@ include::requirements/simpleattr-table_def.adoc[]
 .User-Defined Simple Attributes Table Definition
 [cols=",,,,",options="header",]
 |================================================================================
-|Column Name    |Column Type |Column Description                      |Null |Key
-|_any_          |INTEGER     |Autoincrement primary key               |no   |PK
-|_any_          |TEXT        |Text attribute content                  |no   |
-|_any_          |INTEGER     |Integer attribute content               |no   |
-|_any_          |REAL        |Floating point number attribute content |no   |
+|Column Name    |Column Type |Column Description                      |Null  |Key
+|_any_          |INTEGER     |Autoincrement primary key               |no    |PK
+|_any_          |TEXT        |Text attribute content                  |_any_ |
+|_any_          |INTEGER     |Integer attribute content               |_any_ |
+|_any_          |REAL        |Floating point number attribute content |_any_ |
 |================================================================================
 [NOTE]
 ====


### PR DESCRIPTION
This is not required for interoperability, and is an unwarranted constraint over the base attribute requirements from GeoPackage.